### PR TITLE
use backticks instead of ({

### DIFF
--- a/tests/05-arrow-functions-basics.js
+++ b/tests/05-arrow-functions-basics.js
@@ -28,8 +28,8 @@ describe('arrow functions', function() {
   });
 
   it('body needs parens to return an object', () => {
-    var func = () => ({iAm: 'an object'});
-    assert.deepEqual(func(), {iAm: 'an object'});
+    var func = () => `iAm: 'an object'`;
+    assert.deepEqual(func(), `iAm: 'an object'`);
   });
 
 });


### PR DESCRIPTION
For cleaner code. Or is there reason not to?
