### PR TITLE
Leave asserts unchanged

### DIFF
--- a/tests/08-block-scope-const.js
+++ b/tests/08-block-scope-const.js
@@ -31,14 +31,14 @@ describe('`const` is like `let` plus read-only', () => {
 
     it('array', () => {
       const arr = [42, 23];
-      arr[0] = 0;
-      assert.equal(arr[0], 0);
+      // arr[0] = 0;
+      assert.equal(arr[0], 42);
     });
 
     it('object', () => {
       const obj = {x: 1};
-      obj.x = 2;
-      assert.equal(obj.x, 2);
+      obj.x = 3;
+      assert.equal(obj.x, 3);
     });
 
   });


### PR DESCRIPTION
Your code is also right, but the idea is to leave asserts unchanged (so code other way around ;-) )
By the way, in the 'newest' version (august 2016) the var assert = require("assert") on line 4 is build-in, so you can delete that if you want to (for all katas), but I think this is not really necessary, because it is self-explanatory.
